### PR TITLE
removed lodash.throttle

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,10 +14,6 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _lodash = require('lodash.throttle');
-
-var _lodash2 = _interopRequireDefault(_lodash);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.10",
     "react": "^15.6.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import throttle from 'lodash.throttle'
 
 class InviewMonitor extends Component {
   constructor(props) {


### PR DESCRIPTION
@pocketjoso 
as long as react-inview-monitor uses window.IntersectionObserver now,
lodash.throttle is not anymore needed
