### PR TITLE
yarn "install" is now "add"

### DIFF
--- a/examples/src/components/MainHeader.js
+++ b/examples/src/components/MainHeader.js
@@ -12,7 +12,7 @@ const MainHeader = () =>
     </div>
 
     <div className="main-header__install-cta max-width-2 mx-auto border p1">
-      $ yarn install react-inview-monitor
+      $ yarn add react-inview-monitor
     </div>
   </header>
 


### PR DESCRIPTION
error "install" has been replaced with "add" to add new dependencies. Run `yarn add react-inview-monitor` instead.